### PR TITLE
Set up an action for packaging

### DIFF
--- a/action-steps/build.sh
+++ b/action-steps/build.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+set -o nounset
+
+TOOLS_DIR=${GITHUB_WORKSPACE}/tools
+REPOS_DIR=${GITHUB_WORKSPACE}/repos
+PKG_DIR=${GITHUB_WORKSPACE}/source
+
+cmd () {
+	${TOOLS_DIR}/ulos-runner ${TOOLS_DIR}/liblua ${TOOLS_DIR}/upt/src/bin/$1.lua "$@"
+}
+
+repo=${INPUT_REPO}
+pkgname=${INPUT_PKGNAME}
+prebuild="${INPUT_PREBUILD:-}"
+
+cd $PKG_DIR
+
+if [ "$prebuild" ]; then
+	# todo - pass $PKG_DIR and branch name
+	bash -ec "$prebuild"
+fi
+
+#touch ${REPOS_DIR}/$repo/packages.upl
+
+rm -vf *.mtar
+cmd uptb # | tail -n 1 >> ${REPOS_DIR}/$repo/packages.upl
+
+mkdir -p ${REPOS_DIR}/$repo
+cp *.mtar ${REPOS_DIR}/$repo/

--- a/action-steps/push.sh
+++ b/action-steps/push.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+set -o nounset
+
+REPOS_DIR=${GITHUB_WORKSPACE}/repos
+
+# Create a temporary identity file.
+echo "$INPUT_PUSH_IDENTITY" > ${GITHUB_WORKSPACE}/id
+trap "rm -f ${GITHUB_WORKSPACE}/id" EXIT
+
+# See https://serverfault.com/a/852310 for how to set this up
+scp -i ${GITHUB_WORKSPACE}/id -r ${REPOS_DIR}/${INPUT_REPO} "${INPUT_PUSH_URL}"

--- a/action-steps/setup.sh
+++ b/action-steps/setup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+set -o nounset
+
+mkdir -p ${GITHUB_WORKSPACE}/packages
+
+TOOLS_DIR=${GITHUB_WORKSPACE}/tools
+rm -rf ${TOOLS_DIR}
+
+git clone https://github.com/oc-ulos/liblua.git ${TOOLS_DIR}/liblua
+
+git clone https://github.com/oc-ulos/upt.git ${TOOLS_DIR}/upt
+
+curl https://raw.githubusercontent.com/oc-ulos/ulos-2/primary/tools/ulos-runner > ${TOOLS_DIR}/ulos-runner
+chmod +x ${TOOLS_DIR}/ulos-runner

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,31 @@
+# See https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions
+name: Build and push
+description: Build and push ULOS 2 package to the ULOS package repository
+author: spraints and ocawesome101
+
+inputs:
+  repo:
+    description: 'Package repository (e.g. core)'
+    required: true
+  pkgname:
+    description: 'Name of package (usually the same as the repository name, e.g. coreutils)'
+    required: true
+  prebuild:
+    description: 'Path to a script to run before invoking uptb'
+    required: false
+  push_url:
+    description: 'SSH destination for this repository (should include "repo" path component at the end)'
+    required: true
+  push_identity:
+    description: 'SSH identity (private key) to use when pushing the package'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Setup upt
+      run: ${{ github.action_path }}/action-steps/setup.sh
+    - name: Build package
+      run: ${{ github.action_path }}/action-steps/build.sh
+    - name: Push package
+      run: ${{ github.action_path }}/action-steps/push.sh


### PR DESCRIPTION
This branch sets up this repository as an action that can be used in a workflow in individual packages. I opted to make it a [composite action](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action) because that was an easy way to reuse the existing scripts. The individual steps are based on `update.sh`, but modified with some different assumptions about the Actions runner environment. The `setup` script could be converted into a Dockerfile, which would let this action turn into a [docker container action](https://docs.github.com/en/actions/creating-actions/creating-a-docker-container-action). It might also make sense to split the build and push steps into separate actions, especially if it's possible that you'd want to run them separately. I assume that, like the [docker build-push-action](https://github.com/docker/build-push-action), most or all uses of the "build" step will also "push".

Note that the action currently doesn't create or update the `packages.upl` file.

For example, see https://github.com/oc-ulos/coreutils/pull/5.

```yaml
name: Publish Package

on:
  workflow_dispatch:
  push:
    branches:
      - release

jobs:
  build-and-push-package:
    runs-on: ubuntu-latest
    permissions:
      contents: read

    steps:
      - name: Checkout repository
        uses: actions/checkout@v4
        with:
          path: source

      - name: Build and publish
        uses: oc-ulos/upt-packager@release
        with:
          repo: core
          pkgname: coreutils
          push_url: ${{ secrets.package_push_url }}/core
          push_identity: ${{ secrets.package_push_identity }}
```

cc @Ocawesome101 